### PR TITLE
change the approach to get the host name from virtualservice

### DIFF
--- a/backend/src/helmservice/helmservice.service.ts
+++ b/backend/src/helmservice/helmservice.service.ts
@@ -55,7 +55,7 @@ export class HelmserviceService {
 
         //Add kyma version
         if (process.env.KYMA_VER) {
-            installCommand += ` --set ${process.env.KYMA_VER} `;
+            installCommand += ` --set kyma.version=${process.env.KYMA_VER} `;
         }
 
         //Add release name

--- a/backend/src/kubectl/kubectl.service.ts
+++ b/backend/src/kubectl/kubectl.service.ts
@@ -11,18 +11,48 @@ export class KubectlService {
     }
 
     public async getAccessUrlFromKymaByAppName(appName: string, namespace: string): Promise<string> {
-        const cmdValue = this.buildKubectlCmd4Get('virtualservices', appName, namespace);
-        const result = await this.execKubectlCmd(cmdValue);
+        let cmdValue = this.buildKubectlCmd4Get('virtualservices', appName, namespace);
+        let result = await this.execKubectlCmd(cmdValue);
 
         let accessUrl = '';
         if (result.stdout) {
             const jsonResult = JSON.parse(result.stdout);
             accessUrl = 'https://' + jsonResult.spec.hosts[0];
         } else if (result.stderr) {
-            throw new Error(result.stderr);
+            this.loggerService.warn(result.stderr);
+            // fallback to use label selector 
+            // From Kyma 1.12.0, the APIRule is the only way to expose API
+            // And the name of VirtualService which is owned with the APIRule, has postfix, so we can't simply get it by name
+            cmdValue = this.buildKubectlCmd4GetByLabel('virtualservices',
+                namespace,
+                'apirule.gateway.kyma-project.io/v1alpha1',
+                `${appName}.${namespace}`);
+            result = await this.execKubectlCmd(cmdValue);
+            if (result.stdout) {
+                const jsonResult = JSON.parse(result.stdout);
+                accessUrl = 'https://' + jsonResult.items[0].spec.hosts[0];
+            } else if (result.stderr) {
+                this.loggerService.error(result.stderr);
+                throw new Error("Can't find the relevant VirtualService");
+            }
         }
 
         return accessUrl;
+    }
+
+    private buildKubectlCmd4GetByLabel(kindType: string, namespace: string, labelKey: string, labelValue?: string): string[] {
+        this.validateNotEmpty(kindType, 'kindType');
+        this.validateNotEmpty(labelKey, 'labelKey');
+        this.validateNotEmpty(namespace, 'namespace');
+
+        let cmdValue = '';
+        if (labelValue) {
+            cmdValue = `get ${kindType} -l ${labelKey}=${labelValue} -n ${namespace} --kubeconfig=${KUBE_CONFIG_LOCATION} --output=json`;
+        } else {
+            cmdValue = `get ${kindType} -L ${labelKey} -n ${namespace} --kubeconfig=${KUBE_CONFIG_LOCATION} --output=json`
+        }
+
+        return cmdValue.split(/(\s+)/).filter(e => e.trim().length > 0);
     }
 
     private buildKubectlCmd4Get(kindType: string, value: string, namespace: string): string[] {
@@ -36,7 +66,7 @@ export class KubectlService {
     }
 
     private async execKubectlCmd(cmdValue: string[]) {
-        //Perform helm install command
+        //Perform kubectl command
         const result = {stdout: null, stderr: null};
         try {
             const response = await this.cmdhelperService.runCmd(`${KUBECTL_BINARY_LOCATION}`, cmdValue)


### PR DESCRIPTION
1. after Kyma 1.12, the VirtualService name always has postfix, so we can get VirtualService by name, we have to get it via LabelSelector instead