### PR TITLE
Use installer namespace as default value when deploying extension

### DIFF
--- a/VERSIONINFO
+++ b/VERSIONINFO
@@ -1,2 +1,2 @@
-appVersion=0.2.0
-version=0.2.4
+appVersion=0.3.0
+version=0.3.0

--- a/addons/fsm-extension-installer-0.3.0/chart/fsm-extension-installer/Chart.yaml
+++ b/addons/fsm-extension-installer-0.3.0/chart/fsm-extension-installer/Chart.yaml
@@ -1,0 +1,5 @@
+apiVersion: v1
+appVersion: "0.3.0"
+description: A Helm chart for FSM extension installer (on Kyma)
+name: fsm-extension-installer
+version: 0.3.0

--- a/addons/fsm-extension-installer-0.3.0/chart/fsm-extension-installer/templates/NOTES.txt
+++ b/addons/fsm-extension-installer-0.3.0/chart/fsm-extension-installer/templates/NOTES.txt
@@ -1,0 +1,19 @@
+1. Get the application URL by running these commands:
+{{- if .Values.ingress.enabled }}
+{{- range .Values.ingress.hosts }}
+  http{{ if $.Values.ingress.tls }}s{{ end }}://{{ . }}{{ $.Values.ingress.path }}
+{{- end }}
+{{- else if contains "NodePort" .Values.service.type }}
+  export NODE_PORT=$(kubectl get --namespace {{ .Release.Namespace }} -o jsonpath="{.spec.ports[0].nodePort}" services {{ include "fsm-extension-installer.fullname" . }})
+  export NODE_IP=$(kubectl get nodes --namespace {{ .Release.Namespace }} -o jsonpath="{.items[0].status.addresses[0].address}")
+  echo http://$NODE_IP:$NODE_PORT
+{{- else if contains "LoadBalancer" .Values.service.type }}
+     NOTE: It may take a few minutes for the LoadBalancer IP to be available.
+           You can watch the status of by running 'kubectl get svc -w {{ include "fsm-extension-installer.fullname" . }}'
+  export SERVICE_IP=$(kubectl get svc --namespace {{ .Release.Namespace }} {{ include "fsm-extension-installer.fullname" . }} -o jsonpath='{.status.loadBalancer.ingress[0].ip}')
+  echo http://$SERVICE_IP:{{ .Values.service.port }}
+{{- else if contains "ClusterIP" .Values.service.type }}
+  export POD_NAME=$(kubectl get pods --namespace {{ .Release.Namespace }} -l "app={{ include "fsm-extension-installer.name" . }},release={{ .Release.Name }}" -o jsonpath="{.items[0].metadata.name}")
+  echo "Visit http://127.0.0.1:8080 to use your application"
+  kubectl port-forward $POD_NAME 8080:{{ .Values.service.internalPort }}
+{{- end }}

--- a/addons/fsm-extension-installer-0.3.0/chart/fsm-extension-installer/templates/_helpers.tpl
+++ b/addons/fsm-extension-installer-0.3.0/chart/fsm-extension-installer/templates/_helpers.tpl
@@ -1,0 +1,39 @@
+{{/* vim: set filetype=mustache: */}}
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "fsm-extension-installer.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "fsm-extension-installer.fullname" -}}
+{{- if .Values.fullnameOverride -}}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- $name := default .Chart.Name .Values.nameOverride -}}
+{{- if contains $name .Release.Name -}}
+{{- .Release.Name | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "fsm-extension-installer.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Create event subscription name prefix based on giving application name.
+*/}}
+{{- define "fsm-extension-installer.eventSubscriptionPrefix" -}}
+{{- default .Values.appName | trunc 37 | trimSuffix "-" -}}
+{{- end -}}

--- a/addons/fsm-extension-installer-0.3.0/chart/fsm-extension-installer/templates/configmap.yaml
+++ b/addons/fsm-extension-installer-0.3.0/chart/fsm-extension-installer/templates/configmap.yaml
@@ -1,0 +1,43 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "fsm-extension-installer.fullname" . }}
+  namespace: {{ .Release.Namespace }}
+data:
+  init-kubeconfig.sh: |-
+    #!/bin/sh
+
+    dest="$1"
+    if [[ -z "$dest" ]]; then
+      echo "please specify the destination where kubeconfig file will be writen to"
+      exit
+    fi
+
+    # alpine image has a version of base64 which doesn't provide the -w option, we have to force update it
+    # see: https://stackoverflow.com/questions/57920449/the-error-base64-unrecognized-option-w-is-output-in-alpine-linux
+    apk add --update coreutils
+    ca=`cat /var/run/secrets/kubernetes.io/serviceaccount/ca.crt | base64 -w 0`
+    namespace=`cat /var/run/secrets/kubernetes.io/serviceaccount/namespace`
+    token=`cat /var/run/secrets/kubernetes.io/serviceaccount/token`
+
+    echo "apiVersion: v1
+    clusters:
+    - cluster:
+        certificate-authority-data: ${ca}
+        server: https://${KUBERNETES_SERVICE_HOST}:${KUBERNETES_SERVICE_PORT_HTTPS}
+      name: this-cluster
+    contexts:
+    - context:
+        cluster: this-cluster
+        namespace: ${namespace}
+        user: this-user
+      name: this-context
+    current-context: this-context
+    kind: Config
+    preferences: {}
+    users:
+    - name: this-user
+      user:
+        token: ${token}" > $dest
+
+  

--- a/addons/fsm-extension-installer-0.3.0/chart/fsm-extension-installer/templates/deployment.yaml
+++ b/addons/fsm-extension-installer-0.3.0/chart/fsm-extension-installer/templates/deployment.yaml
@@ -1,0 +1,87 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "fsm-extension-installer.fullname" . }}
+  labels:
+    app: {{ include "fsm-extension-installer.name" . }}
+    chart: {{ include "fsm-extension-installer.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+spec:
+  replicas: 1
+  strategy:
+    rollingUpdate:
+      maxSurge: 1
+      maxUnavailable: 0
+  selector:
+    matchLabels:
+      app: {{ include "fsm-extension-installer.name" . }}
+      release: {{ .Release.Name }}
+  template:
+    metadata:
+      labels:
+        app: {{ include "fsm-extension-installer.name" . }}
+        release: {{ .Release.Name }}
+    spec:
+      serviceAccountName: {{ include "fsm-extension-installer.fullname" . }}
+      initContainers:
+        - name: {{ .Chart.Name }}-init
+          image: alpine:3.11.6
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          args: ["sh",  "/config/init-kubeconfig.sh", "/share/kubeconfig"]
+          volumeMounts:
+            - mountPath: /share
+              name: share
+            - mountPath: /config
+              name: config
+              readOnly: true
+      containers:
+        - name: {{ .Chart.Name }}
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          env:
+            - name: SHARE_DIR
+              value: "/share"
+            - name: KYMA_VER
+              value: {{ .Values.kyma.version }}
+            - name: INSTALLER_NAMESPACE
+              value: {{ .Release.Namespace }}
+          ports:
+            - name: http
+              containerPort: {{ .Values.service.internalPort }}
+              protocol: TCP
+          volumeMounts:
+            - mountPath: /share
+              name: share
+          livenessProbe:
+            httpGet:
+              path: /api/fsm-extension-installer/v1/status
+              port: http
+          readinessProbe:
+            httpGet:
+              path: /api/fsm-extension-installer/v1/status
+              port: http
+          securityContext:
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+          resources:
+{{ toYaml .Values.resources | indent 12 }}
+    {{- with .Values.nodeSelector }}
+      nodeSelector:
+{{ toYaml . | indent 8 }}
+    {{- end }}
+    {{- with .Values.affinity }}
+      affinity:
+{{ toYaml . | indent 8 }}
+    {{- end }}
+    {{- with .Values.tolerations }}
+      tolerations:
+{{ toYaml . | indent 8 }}
+    {{- end }}
+      volumes:
+        - name: share
+          emptyDir:
+            sizeLimit: 64Mi
+        - name: config
+          configMap:
+            name:  {{ include "fsm-extension-installer.fullname" . }}

--- a/addons/fsm-extension-installer-0.3.0/chart/fsm-extension-installer/templates/event-subcription.yaml
+++ b/addons/fsm-extension-installer-0.3.0/chart/fsm-extension-installer/templates/event-subcription.yaml
@@ -1,0 +1,90 @@
+{{- /*
+ Use sprig semver function to do the version comparison
+https://github.com/helm/charts/issues/3002
+https://masterminds.github.io/sprig/semver.html 
+*/ -}}
+{{- if gt (semver .Values.kyma.version | (semver "1.11.0-0").Compare) 0 -}}
+apiVersion: eventing.kyma-project.io/v1alpha1
+kind: Subscription
+metadata:
+  name: {{ include "fsm-extension-installer.eventSubscriptionPrefix" . }}-install-ev-subscription
+  namespace: {{ .Release.Namespace }}
+spec:
+  endpoint: http://{{ include "fsm-extension-installer.fullname" . }}.{{ .Release.Namespace }}:{{ .Values.service.port }}/api/fsm-extension-installer/v1/install
+  event_type: extensioncatalog.extension.install.requested
+  event_type_version: v1
+  include_subscription_name_header: true
+  source_id: {{ required "Application Name must be provided!" .Values.appName }}
+---
+apiVersion: eventing.kyma-project.io/v1alpha1
+kind: Subscription
+metadata:
+  name: {{ include "fsm-extension-installer.eventSubscriptionPrefix" . }}-uninstall-ev-subscription
+  namespace: {{ .Release.Namespace }}
+spec:
+  endpoint: http://{{ include "fsm-extension-installer.fullname" . }}.{{ .Release.Namespace }}:{{ .Values.service.port }}/api/fsm-extension-installer/v1/uninstall
+  event_type: extensioncatalog.extension.uninstall.requested
+  event_type_version: v1
+  include_subscription_name_header: true
+  source_id: {{ required "Application Name must be provided!" .Values.appName }}
+---
+apiVersion: eventing.kyma-project.io/v1alpha1
+kind: Subscription
+metadata:
+  name: {{ include "fsm-extension-installer.eventSubscriptionPrefix" . }}-upgrade-ev-subscription
+  namespace: {{ .Release.Namespace }}
+spec:
+  endpoint: http://{{ include "fsm-extension-installer.fullname" . }}.{{ .Release.Namespace }}:{{ .Values.service.port }}/api/fsm-extension-installer/v1/upgrade
+  event_type: extensioncatalog.extension.upgrade.requested
+  event_type_version: v1
+  include_subscription_name_header: true
+  source_id: {{ required "Application Name must be provided!" .Values.appName }}
+{{- end }}
+
+
+{{- if lt (semver .Values.kyma.version | (semver "1.11.0-0").Compare) 0 -}}
+apiVersion: eventing.knative.dev/v1alpha1
+kind: Trigger
+metadata:
+  name: {{ include "fsm-extension-installer.eventSubscriptionPrefix" . }}-install-ev-subscription
+  namespace: {{ .Release.Namespace }}
+spec:
+  broker: default
+  filter:
+    attributes:
+      eventtypeversion: v1
+      source: {{ required "Application Name must be provided!" .Values.appName }}
+      type: extensioncatalog.extension.install.requested
+  subscriber:
+    uri: http://{{ include "fsm-extension-installer.fullname" . }}.{{ .Release.Namespace }}:{{ .Values.service.port }}/api/fsm-extension-installer/v1/install/
+---
+apiVersion: eventing.knative.dev/v1alpha1
+kind: Trigger
+metadata:
+  name: {{ include "fsm-extension-installer.eventSubscriptionPrefix" . }}-uninstall-ev-subscription
+  namespace: {{ .Release.Namespace }}
+spec:
+  broker: default
+  filter:
+    attributes:
+      eventtypeversion: v1
+      source: {{ required "Application Name must be provided!" .Values.appName }}
+      type: extensioncatalog.extension.uninstall.requested
+  subscriber:
+    uri: http://{{ include "fsm-extension-installer.fullname" . }}.{{ .Release.Namespace }}:{{ .Values.service.port }}/api/fsm-extension-installer/v1/uninstall/
+---
+apiVersion: eventing.knative.dev/v1alpha1
+kind: Trigger
+metadata:
+  name: {{ include "fsm-extension-installer.eventSubscriptionPrefix" . }}-upgrade-ev-subscription
+  namespace: {{ .Release.Namespace }}
+spec:
+  broker: default
+  filter:
+    attributes:
+      eventtypeversion: v1
+      source: {{ required "Application Name must be provided!" .Values.appName }}
+      type: extensioncatalog.extension.upgrade.requested
+  subscriber:
+    uri: http://{{ include "fsm-extension-installer.fullname" . }}.{{ .Release.Namespace }}:{{ .Values.service.port }}/api/fsm-extension-installer/v1/upgrade/
+{{- end }}

--- a/addons/fsm-extension-installer-0.3.0/chart/fsm-extension-installer/templates/ingress.yaml
+++ b/addons/fsm-extension-installer-0.3.0/chart/fsm-extension-installer/templates/ingress.yaml
@@ -1,0 +1,38 @@
+{{- if .Values.ingress.enabled -}}
+{{- $fullName := include "fsm-extension-installer.fullname" . -}}
+{{- $ingressPath := .Values.ingress.path -}}
+apiVersion: extensions/v1beta1
+kind: Ingress
+metadata:
+  name: {{ $fullName }}
+  labels:
+    app: {{ include "fsm-extension-installer.name" . }}
+    chart: {{ include "fsm-extension-installer.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+{{- with .Values.ingress.annotations }}
+  annotations:
+{{ toYaml . | indent 4 }}
+{{- end }}
+spec:
+{{- if .Values.ingress.tls }}
+  tls:
+  {{- range .Values.ingress.tls }}
+    - hosts:
+      {{- range .hosts }}
+        - {{ . | quote }}
+      {{- end }}
+      secretName: {{ .secretName }}
+  {{- end }}
+{{- end }}
+  rules:
+  {{- range .Values.ingress.hosts }}
+    - host: {{ . | quote }}
+      http:
+        paths:
+          - path: {{ $ingressPath }}
+            backend:
+              serviceName: {{ $fullName }}
+              servicePort: http
+  {{- end }}
+{{- end }}

--- a/addons/fsm-extension-installer-0.3.0/chart/fsm-extension-installer/templates/rbac.yaml
+++ b/addons/fsm-extension-installer-0.3.0/chart/fsm-extension-installer/templates/rbac.yaml
@@ -1,0 +1,28 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "fsm-extension-installer.fullname" . }}
+  namespace: {{ .Release.Namespace }}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: {{ include "fsm-extension-installer.fullname" . }}
+rules:
+- apiGroups: ["*"]
+  resources: ["*"]
+  verbs: ["*"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: {{ include "fsm-extension-installer.fullname" . }}
+  namespace: {{ .Release.Namespace }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: {{ include "fsm-extension-installer.fullname" . }}
+subjects:
+- kind: ServiceAccount
+  name: {{ include "fsm-extension-installer.fullname" . }}
+  namespace: {{ .Release.Namespace }}

--- a/addons/fsm-extension-installer-0.3.0/chart/fsm-extension-installer/templates/service.yaml
+++ b/addons/fsm-extension-installer-0.3.0/chart/fsm-extension-installer/templates/service.yaml
@@ -1,0 +1,20 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "fsm-extension-installer.fullname" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app: {{ include "fsm-extension-installer.name" . }}
+    chart: {{ include "fsm-extension-installer.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+spec:
+  type: {{ .Values.service.type }}
+  ports:
+    - port: {{ .Values.service.port }}
+      targetPort: {{ .Values.service.internalPort }}
+      protocol: TCP
+      name: http
+  selector:
+    app: {{ include "fsm-extension-installer.name" . }}
+    release: {{ .Release.Name }}

--- a/addons/fsm-extension-installer-0.3.0/chart/fsm-extension-installer/templates/servicebinding.yaml
+++ b/addons/fsm-extension-installer-0.3.0/chart/fsm-extension-installer/templates/servicebinding.yaml
@@ -1,0 +1,20 @@
+apiVersion: servicecatalog.k8s.io/v1beta1
+kind: ServiceBinding
+metadata:
+  name: {{ include "fsm-extension-installer.fullname" . }}
+  namespace: {{ .Release.Namespace }}
+spec:
+  instanceRef:
+    name: {{ required "ServiceInstance Name must be provided!" .Values.serviceInstanceName }}
+---
+apiVersion: servicecatalog.kyma-project.io/v1alpha1
+kind: ServiceBindingUsage
+metadata:
+  name: {{ include "fsm-extension-installer.fullname" . }}
+  namespace: {{ .Release.Namespace }}
+spec:
+  serviceBindingRef:
+    name: {{ include "fsm-extension-installer.fullname" . }}
+  usedBy:
+    kind: deployment
+    name: {{ include "fsm-extension-installer.fullname" . }}

--- a/addons/fsm-extension-installer-0.3.0/chart/fsm-extension-installer/values.yaml
+++ b/addons/fsm-extension-installer-0.3.0/chart/fsm-extension-installer/values.yaml
@@ -3,7 +3,7 @@
 # Declare variables to be passed into your templates.
 
 image:
-  repository: i503740/fsm-extension-installer-for-kyma
+  repository: sapfsm/fsm-extension-installer-for-kyma
   tag: 0.3.0
   pullPolicy: Always
 

--- a/addons/fsm-extension-installer-0.3.0/chart/fsm-extension-installer/values.yaml
+++ b/addons/fsm-extension-installer-0.3.0/chart/fsm-extension-installer/values.yaml
@@ -1,0 +1,57 @@
+# Default values for fsm-extension-installer.
+# This is a YAML-formatted file.
+# Declare variables to be passed into your templates.
+
+image:
+  repository: i503740/fsm-extension-installer-for-kyma
+  tag: 0.3.0
+  pullPolicy: Always
+
+nameOverride: ""
+fullnameOverride: ""
+
+service:
+  type: ClusterIP
+  port: 80
+  internalPort: 8000
+
+ingress:
+  enabled: false
+  annotations: {}
+    # kubernetes.io/ingress.class: nginx
+    # kubernetes.io/tls-acme: "true"
+  path: /
+  hosts:
+    - chart-example.local
+  tls: []
+  #  - secretName: chart-example-tls
+  #    hosts:
+  #      - chart-example.local
+
+resources:
+  # We usually recommend not to specify default resources and to leave this as a conscious
+  # choice for the user. This also increases chances charts run on environments with little
+  # resources, such as Minikube. If you do want to specify resources, uncomment the following
+  # lines, adjust them as necessary, and remove the curly braces after 'resources:'.
+  limits:
+    cpu: 120m
+    memory: 500Mi
+  requests:
+    cpu: 60m
+    memory: 250Mi
+
+nodeSelector: {}
+
+tolerations: []
+
+affinity: {}
+
+# Name of the application which is connected with the FSM tenant
+appName: ""
+
+# Name of the service instance which is provisioned from the service class "Extension Catalog API"
+serviceInstanceName: ""
+
+kyma:
+  # The exact version number like "1.11.0", "1.11.0-rc1"
+  version: ""

--- a/addons/fsm-extension-installer-0.3.0/meta.yaml
+++ b/addons/fsm-extension-installer-0.3.0/meta.yaml
@@ -1,6 +1,6 @@
 name: fsm-extension-installer
 version: 0.3.0
-id: 3c2fbde7-9516-463d-bd0c-e45173dda6cf
+id: 57b51964-e910-44b3-8fe1-245fc50e24d7
 description: "A simple addon to enable installing FSM extension on Kyma"
 displayName: "FSM Extension Installer For Kyma"
 providerDisplayName: "FSM"

--- a/addons/fsm-extension-installer-0.3.0/meta.yaml
+++ b/addons/fsm-extension-installer-0.3.0/meta.yaml
@@ -1,0 +1,8 @@
+name: fsm-extension-installer
+version: 0.3.0
+id: 3c2fbde7-9516-463d-bd0c-e45173dda6cf
+description: "A simple addon to enable installing FSM extension on Kyma"
+displayName: "FSM Extension Installer For Kyma"
+providerDisplayName: "FSM"
+documentationURL: https://github.com/SAP-samples/fsm-extension-installer-kyma/blob/master/README.md
+tags: FSM, extension-installer, 0.3.0, broker

--- a/addons/fsm-extension-installer-0.3.0/plans/default/create-instance-schema.json
+++ b/addons/fsm-extension-installer-0.3.0/plans/default/create-instance-schema.json
@@ -1,0 +1,34 @@
+{
+    "$schema": "http://json-schema.org/draft-04/schema#",
+    "type": "object",
+    "properties": {
+        "appName": {
+            "type": "string",
+            "title": "Application Name",
+            "description": "Name of the application which is connected with the FSM tenant"
+        },
+        "serviceInstanceName": {
+            "type": "string",
+            "title": "Service Instance Name",
+            "description": "Name of the service instance which is provisioned from the service class \"Extension Catalog API\""
+        },
+        "kyma": {
+            "type": "object",
+            "title": "Kyma",
+            "properties": {
+                "version": {
+                    "type": "string",
+                    "title": "Version",
+                    "description": "The exact version number like \"1.11.0\", \"1.11.0-rc1\""
+                }
+            },
+            "required": [
+                "version"
+            ]
+        }
+    },
+    "required": [
+        "appName",
+        "serviceInstanceName"
+    ]
+}

--- a/addons/fsm-extension-installer-0.3.0/plans/default/meta.yaml
+++ b/addons/fsm-extension-installer-0.3.0/plans/default/meta.yaml
@@ -1,0 +1,5 @@
+name: default
+id: 3c2fbde7-9516-463d-bd0c-e45173dda6cf
+description: "Default plan"
+displayName: Default
+free: true

--- a/addons/fsm-extension-installer-0.3.0/plans/default/meta.yaml
+++ b/addons/fsm-extension-installer-0.3.0/plans/default/meta.yaml
@@ -1,5 +1,5 @@
 name: default
-id: 3c2fbde7-9516-463d-bd0c-e45173dda6cf
+id: 57b51964-e910-44b3-8fe1-245fc50e24d7
 description: "Default plan"
 displayName: Default
 free: true

--- a/addons/index.yaml
+++ b/addons/index.yaml
@@ -3,4 +3,4 @@ entries:
   fsm-extension-installer:
     - name: fsm-extension-installer
       description: "A simple addon to enable installing FSM extension on Kyma"
-      version: 0.2.4
+      version: 0.3.0

--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -2571,9 +2571,9 @@
       }
     },
     "bl": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/bl/-/bl-1.2.2.tgz",
-      "integrity": "sha512-e8tQYnZodmebYDWGH7KMRvtzKXaJHx3BbilrgZCfvyLUYdKpK1t5PSPmpkny/SgiTSCnjfLW7v5rlONXVFkQEA==",
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/bl/-/bl-1.2.3.tgz",
+      "integrity": "sha512-pvcNpa0UU69UT341rO6AYy4FVAIkUHuZXRIWbq+zHnsVcRzDDjIAhGuuYoi0d//cwIwtt4pkpKycWEfjdV+vww==",
       "requires": {
         "readable-stream": "^2.3.5",
         "safe-buffer": "^5.1.1"
@@ -3976,9 +3976,9 @@
       "integrity": "sha1-WQxhFWsK4vTwJVcyoViyZrxWsh0="
     },
     "elliptic": {
-      "version": "6.5.2",
-      "resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.5.2.tgz",
-      "integrity": "sha512-f4x70okzZbIQl/NSRLkI/+tteV/9WqL98zx+SQ69KbXxmVrmjwsNUPn/gYJJ0sHvEak24cZgHIPegRePAtA/xw==",
+      "version": "6.5.3",
+      "resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.5.3.tgz",
+      "integrity": "sha512-IMqzv5wNQf+E6aHeIqATs0tOLeOTwj1QKbRcS3jBbYkl5oLAserA8yJTT7/VyHUYG91PRmPyeQDObKLPpeS4dw==",
       "dev": true,
       "requires": {
         "bn.js": "^4.4.0",
@@ -3991,9 +3991,9 @@
       },
       "dependencies": {
         "bn.js": {
-          "version": "4.11.8",
-          "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.11.8.tgz",
-          "integrity": "sha512-ItfYfPLkWHUjckQCk8xC+LwxgK8NYcXywGigJgSwOP8Y2iyWT4f2vsZnoOXTTbo+o5yXmIUJ4gn5538SO5S3gA==",
+          "version": "4.11.9",
+          "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.11.9.tgz",
+          "integrity": "sha512-E6QoYqCKZfgatHTdHzs1RRKP7ip4vvm+EyRUeE2RF0NblwVvb0p6jSVeNTOFxPn26QXN2o6SMfNxKp6kU8zQaw==",
           "dev": true
         }
       }
@@ -8417,9 +8417,9 @@
       }
     },
     "node-fetch": {
-      "version": "2.6.0",
-      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.0.tgz",
-      "integrity": "sha512-8dG4H5ujfvFiqDmVu9fQ5bOHUC15JMjMY/Zumv26oOvvVJjM67KF8koCWIabKQ1GJIa9r2mMZscBq/TbdOcmNA=="
+      "version": "2.6.1",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.1.tgz",
+      "integrity": "sha512-V4aYg89jEoVRxRb2fJdAg8FHvI7cEyYdVAh94HH0UIK8oJxUfkjlDQN9RbMx+bEjP7+ggMiFRprSti032Oipxw=="
     },
     "node-int64": {
       "version": "0.4.0",
@@ -9896,10 +9896,13 @@
       }
     },
     "serialize-javascript": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-2.1.2.tgz",
-      "integrity": "sha512-rs9OggEUF0V4jUSecXazOYsLfu7OGK2qIn3c7IPBiffz32XniEp/TX9Xmc9LQfK2nQ2QKHvZ2oygKUGU0lG4jQ==",
-      "dev": true
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-4.0.0.tgz",
+      "integrity": "sha512-GaNA54380uFefWghODBWEGisLZFj00nS5ACs6yHa9nLqlLpVLO8ChDGeKRjZnV4Nh4n0Qi7nhYZD/9fCPzEqkw==",
+      "dev": true,
+      "requires": {
+        "randombytes": "^2.1.0"
+      }
     },
     "serve-static": {
       "version": "1.14.1",
@@ -10809,9 +10812,9 @@
       }
     },
     "terser": {
-      "version": "4.7.0",
-      "resolved": "https://registry.npmjs.org/terser/-/terser-4.7.0.tgz",
-      "integrity": "sha512-Lfb0RiZcjRDXCC3OSHJpEkxJ9Qeqs6mp2v4jf2MHfy8vGERmVDuvjXdd/EnP5Deme5F2yBRBymKmKHCBg2echw==",
+      "version": "4.8.0",
+      "resolved": "https://registry.npmjs.org/terser/-/terser-4.8.0.tgz",
+      "integrity": "sha512-EAPipTNeWsb/3wLPeup1tVPaXfIaU68xMnVdPafIL1TV05OhASArYyIfFvnvJCNrR2NIOvDVNNTFRa+Re2MWyw==",
       "dev": true,
       "requires": {
         "commander": "^2.20.0",
@@ -10834,16 +10837,16 @@
       }
     },
     "terser-webpack-plugin": {
-      "version": "1.4.3",
-      "resolved": "https://registry.npmjs.org/terser-webpack-plugin/-/terser-webpack-plugin-1.4.3.tgz",
-      "integrity": "sha512-QMxecFz/gHQwteWwSo5nTc6UaICqN1bMedC5sMtUc7y3Ha3Q8y6ZO0iCR8pq4RJC8Hjf0FEPEHZqcMB/+DFCrA==",
+      "version": "1.4.5",
+      "resolved": "https://registry.npmjs.org/terser-webpack-plugin/-/terser-webpack-plugin-1.4.5.tgz",
+      "integrity": "sha512-04Rfe496lN8EYruwi6oPQkG0vo8C+HT49X687FZnpPF0qMAIHONI6HEXYPKDOE8e5HjXTyKfqRd/agHtH0kOtw==",
       "dev": true,
       "requires": {
         "cacache": "^12.0.2",
         "find-cache-dir": "^2.1.0",
         "is-wsl": "^1.1.0",
         "schema-utils": "^1.0.0",
-        "serialize-javascript": "^2.1.2",
+        "serialize-javascript": "^4.0.0",
         "source-map": "^0.6.1",
         "terser": "^4.1.2",
         "webpack-sources": "^1.4.0",

--- a/backend/src/extensioncatalogservice/extensioncatalogservice.service.ts
+++ b/backend/src/extensioncatalogservice/extensioncatalogservice.service.ts
@@ -1,12 +1,12 @@
-import {HttpService, Injectable, Logger, LoggerService} from '@nestjs/common';
-import {AxiosRequestConfig} from 'axios';
+import { HttpService, Injectable, Logger, LoggerService } from '@nestjs/common';
+import { AxiosRequestConfig } from 'axios';
 
-import {DeployConfigData} from '../utils/interfaces/deployconfigdata.interface';
-import {UpdatedDeployData} from '../utils/interfaces/updateddeploydata.interface';
-import {DeployResultData} from '../utils/interfaces/deployresultdata.interface';
-import {ChartConfigData} from '../utils/interfaces/chartconfigdata.interface';
-import {RequestInstallData} from '../utils/interfaces/requestdata.interface';
-import {KYMA_SERVICE_CLASS_GATEWAY_URL} from '../utils/constants';
+import { DeployConfigData } from '../utils/interfaces/deployconfigdata.interface';
+import { UpdatedDeployData } from '../utils/interfaces/updateddeploydata.interface';
+import { DeployResultData } from '../utils/interfaces/deployresultdata.interface';
+import { ChartConfigData } from '../utils/interfaces/chartconfigdata.interface';
+import { RequestInstallData } from '../utils/interfaces/requestdata.interface';
+import { INSTALLER_NAMESPACE, KYMA_SERVICE_CLASS_GATEWAY_URL } from '../utils/constants';
 
 @Injectable()
 export class ExtensionCatalogService {
@@ -31,11 +31,12 @@ export class ExtensionCatalogService {
 
             const retValue = await this.httpService.get(url, config).toPromise();
             const deploymentObj = retValue.data;
+
             this.loggerService.log("DeploymentConfigData:");
             this.loggerService.log(deploymentObj);
             return {
-                // Enhancement: set namespace to 'default' if user not fill namespace value
-                namespace: (deploymentObj.deploymentConfig && deploymentObj.deploymentConfig.namespace) ? deploymentObj.deploymentConfig.namespace : 'default',
+                // namespace is set to the INSTALLER_NAMESPACE if nothing provided in deploymentConfig
+                namespace: (deploymentObj.deploymentConfig && deploymentObj.deploymentConfig.namespace) ? deploymentObj.deploymentConfig.namespace : INSTALLER_NAMESPACE,
                 parameterValues: deploymentObj.deploymentConfig ? deploymentObj.deploymentConfig.values : null,
                 appVersion: deploymentObj.extension.version,
                 chartConfigData: {

--- a/backend/src/utils/constants.ts
+++ b/backend/src/utils/constants.ts
@@ -1,5 +1,5 @@
 //Define saved helm-chart files path after downloading it from github.
-export const CHART_CACHE_PATH: string = (process.env.SHARE_DIR? process.env.SHARE_DIR: process.cwd()) +'/chart_caches/';
+export const CHART_CACHE_PATH: string = (process.env.SHARE_DIR ? process.env.SHARE_DIR : process.cwd()) + '/chart_caches/';
 
 //Define path of helm-cli(must be v3!!!) and kubectl-cli, default initialized via ENV command in Dockerfile file.
 export const HELM_BINARY_LOCATION: string = process.env.HELM_BINARY || '/usr/local/bin/helm3';
@@ -13,3 +13,6 @@ export const KUBE_CONFIG_LOCATION: string = process.env.KUBECONFIG_PATH || '~/.k
 
 //Define the version of Kyma which the installer is setup on
 export const KYMA_VER: string = process.env.KYMA_VER;
+
+//Define the namespace in which the installer is set up
+export const INSTALLER_NAMESPACE: string = process.env.INSTALLER_NAMESPACE || 'default';

--- a/helm/fsm-extension-installer/templates/deployment.yaml
+++ b/helm/fsm-extension-installer/templates/deployment.yaml
@@ -44,6 +44,8 @@ spec:
               value: "/share"
             - name: KYMA_VER
               value: {{ .Values.kyma.version }}
+            - name: INSTALLER_NAMESPACE
+              value: {{ .Release.Namespace }}
           ports:
             - name: http
               containerPort: {{ .Values.service.internalPort }}

--- a/helm/fsm-extension-installer/values.yaml
+++ b/helm/fsm-extension-installer/values.yaml
@@ -3,7 +3,7 @@
 # Declare variables to be passed into your templates.
 
 image:
-  repository: sapfsm/fsm-extension-installer-for-kyma
+  repository: i503740/fsm-extension-installer-for-kyma
   tag: ${appVersion}
   pullPolicy: Always
 

--- a/helm/fsm-extension-installer/values.yaml
+++ b/helm/fsm-extension-installer/values.yaml
@@ -3,7 +3,7 @@
 # Declare variables to be passed into your templates.
 
 image:
-  repository: i503740/fsm-extension-installer-for-kyma
+  repository: sapfsm/fsm-extension-installer-for-kyma
   tag: ${appVersion}
   pullPolicy: Always
 

--- a/internal/build.sh
+++ b/internal/build.sh
@@ -10,9 +10,9 @@ npm run build:prod
 cd ..
 
 echo "======docker build=================================="
-docker build -t i503740/fsm-extension-installer-for-kyma:$appVersion .
+docker build -t sapfsm/fsm-extension-installer-for-kyma:$appVersion .
 
 echo "======docker push=================================="
-docker push i503740/fsm-extension-installer-for-kyma:$appVersion
+docker push sapfsm/fsm-extension-installer-for-kyma:$appVersion
 
 echo "Extension installer is built successfully!"

--- a/internal/build.sh
+++ b/internal/build.sh
@@ -10,9 +10,9 @@ npm run build:prod
 cd ..
 
 echo "======docker build=================================="
-docker build -t sapfsm/fsm-extension-installer-for-kyma:$appVersion .
+docker build -t i503740/fsm-extension-installer-for-kyma:$appVersion .
 
 echo "======docker push=================================="
-docker push sapfsm/fsm-extension-installer-for-kyma:$appVersion
+docker push i503740/fsm-extension-installer-for-kyma:$appVersion
 
 echo "Extension installer is built successfully!"


### PR DESCRIPTION
- updated dependencies (fixed vulnerabilities)
- instead of the default namespace, the installer's namespace is now used when deploying an extension on kyma